### PR TITLE
fix(traefikv3): add additional traefik v3 api group

### DIFF
--- a/charts/kuma-ingress-watcher/templates/clusterrole.yaml
+++ b/charts/kuma-ingress-watcher/templates/clusterrole.yaml
@@ -9,7 +9,7 @@ rules:
     verbs: ["get", "list", "watch"]
   {{- end }}
   {{- if .Values.kumaIngressWatcher.ingressRoute.enabled }}
-  - apiGroups: ["traefik.containo.us"]
+  - apiGroups: ["traefik.containo.us", "traefik.io"]
     resources: ["ingressroutes"]
     verbs: ["get", "list", "watch"]
   {{- end }}


### PR DESCRIPTION
Need to add `traefik.io` to API groups for the traefikv3 upgrade to work properly
