### PR TITLE
feat(file-based-creation): add feature for file based monitor creation

### DIFF
--- a/charts/kuma-ingress-watcher/Chart.yaml
+++ b/charts/kuma-ingress-watcher/Chart.yaml
@@ -13,5 +13,5 @@ keywords:
   - Ingress
   - uptime-Kuma
   - Traefik
-version: 1.3.0
-appVersion: "1.6.0"
+version: 1.4.0
+appVersion: "1.7.0"

--- a/charts/kuma-ingress-watcher/README.md
+++ b/charts/kuma-ingress-watcher/README.md
@@ -1,6 +1,6 @@
 # kuma-ingress-watcher
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
 
 A Helm chart for Kuma ingress watcher. it is a kubernetes controller designed to automatically monitor Traefik Ingress routes and/or kubernetes Ingress object in a Kubernetes cluster and create corresponding monitors in Uptime Kuma.
 
@@ -34,14 +34,16 @@ A Helm chart for Kuma ingress watcher. it is a kubernetes controller designed to
 |-----|------|---------|-------------|
 | clusterRole.name | string | `"ingress-reader"` |  |
 | clusterRoleBinding.name | string | `"kuma-ingress-reader-binding"` |  |
-| configMap.name | string | `"controller-scripts"` |  |
 | deployment.image.name | string | `"ghcr.io/squent/kuma-ingress-watcher"` |  |
 | deployment.label | string | `"kuma-ingress-watcher"` |  |
 | deployment.logLevel | string | `"INFO"` |  |
 | deployment.name | string | `"kuma-ingress-watcher"` |  |
 | deployment.replicas | int | `1` |  |
-| kumaIngressWatcher.ingress.enabled | bool | `true` |  |
-| kumaIngressWatcher.ingressRoute.enabled | bool | `false` |  |
+| kumaIngressWatcher.fileBasedMonitors.enabled | bool | `false` |  |
+| kumaIngressWatcher.fileBasedMonitors.monitors | string | `nil` |  |
+| kumaIngressWatcher.fileBasedMonitors.monitorsFilePath | string | `"/etc/kuma-controller/monitors.yaml"` |  |
+| kumaIngressWatcher.ingress.enabled | bool | `false` |  |
+| kumaIngressWatcher.ingressRoute.enabled | bool | `true` |  |
 | kumaIngressWatcher.ingressRoute.traefikv3 | bool | `false` |  |
 | kumaIngressWatcher.watchInterval | int | `10` |  |
 | namespace | string | `"monitoring"` |  |

--- a/charts/kuma-ingress-watcher/templates/clusterrole.yaml
+++ b/charts/kuma-ingress-watcher/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.kumaIngressWatcher.ingress.enabled .Values.kumaIngressWatcher.ingressRoute.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -16,3 +17,4 @@ rules:
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list"]
+{{- end }}

--- a/charts/kuma-ingress-watcher/templates/clusterrolebinding.yaml
+++ b/charts/kuma-ingress-watcher/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.kumaIngressWatcher.ingress.enabled .Values.kumaIngressWatcher.ingressRoute.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -10,3 +11,4 @@ roleRef:
   kind: ClusterRole
   name: {{ .Values.clusterRole.name }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/kuma-ingress-watcher/templates/configmap.yaml
+++ b/charts/kuma-ingress-watcher/templates/configmap.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.kumaIngressWatcher.fileBasedMonitors.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-monitors
+  namespace: {{ .Values.namespace }}
+data:
+  monitors.yaml: |
+    {{- toYaml .Values.kumaIngressWatcher.fileBasedMonitors.monitors | nindent 4 }}
+{{- end }}

--- a/charts/kuma-ingress-watcher/templates/job.yaml
+++ b/charts/kuma-ingress-watcher/templates/job.yaml
@@ -1,25 +1,16 @@
-{{- if or .Values.kumaIngressWatcher.ingress.enabled .Values.kumaIngressWatcher.ingressRoute.enabled }}
-apiVersion: apps/v1
-kind: Deployment
+{{- if and .Values.kumaIngressWatcher.fileBasedMonitors.enabled (not .Values.kumaIngressWatcher.ingress.enabled) (not .Values.kumaIngressWatcher.ingressRoute.enabled) }}
+apiVersion: batch/v1
+kind: Job
 metadata:
-  name: {{ .Values.deployment.name | default "kuma-ingress-watcher" }}
+  name: {{ .Values.deployment.name | default "kuma-ingress-watcher-job" }}
   namespace: {{ .Values.namespace }}
 spec:
-  replicas: {{ .Values.deployment.replicas | default 1 }}
-  strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
-    type: RollingUpdate
-  selector:
-    matchLabels:
-      app: {{ "kuma-ingress-watcher" }}
   template:
     metadata:
       labels:
         app: {{ "kuma-ingress-watcher" }}
     spec:
-      serviceAccountName: {{ .Values.serviceAccount.name }}
+      restartPolicy: Never
       containers:
       - name: controller
         ports:
@@ -32,14 +23,16 @@ spec:
           value: "{{ .Values.deployment.logLevel }}"
         - name: UPTIME_KUMA_URL
           value: "{{ .Values.uptimeKuma.url }}"
-        - name: WATCH_INTERVAL
-          value: "{{ .Values.kumaIngressWatcher.watchInterval | default `10` }}"
         - name: WATCH_INGRESSROUTES
           value: "{{ .Values.kumaIngressWatcher.ingressRoute.enabled }}"
-        - name: USE_TRAEFIK_V3_CRD_GROUP
-          value: "{{ .Values.kumaIngressWatcher.ingressRoute.traefikv3 }}"
         - name: WATCH_INGRESS
           value: "{{ .Values.kumaIngressWatcher.ingress.enabled }}"
+        - name: WATCH_INTERVAL
+          value: "{{ .Values.kumaIngressWatcher.watchInterval | default `10` }}"
+        - name: ENABLE_FILE_MONITOR
+          value: "{{ .Values.kumaIngressWatcher.fileBasedMonitors.enabled | default `false` }}"
+        - name: MONITORS_FILE_PATH
+          value: "{{ .Values.kumaIngressWatcher.fileBasedMonitors.monitorsFilePath | default `/etc/kuma-controller/monitors.yaml` }}"
         - name: UPTIME_KUMA_USER
           valueFrom:
             secretKeyRef:
@@ -50,20 +43,12 @@ spec:
             secretKeyRef:
               name: {{ .Values.uptimeKuma.credentialsSecret }}
               key: password
-        - name: ENABLE_FILE_MONITOR
-          value: "{{ .Values.kumaIngressWatcher.fileBasedMonitors.enabled | default `false` }}"
-        - name: MONITORS_FILE_PATH
-          value: "{{ .Values.kumaIngressWatcher.fileBasedMonitors.monitorsFilePath | default `/etc/kuma/monitors.yaml` }}"
-        {{- if .Values.kumaIngressWatcher.fileBasedMonitors.enabled }}
         volumeMounts:
         - name: monitors-file
-          mountPath: "{{ .Values.kumaIngressWatcher.fileBasedMonitors.monitorsFilePath | default `/etc/kuma/monitors.yaml` }}"
+          mountPath: "{{ .Values.kumaIngressWatcher.fileBasedMonitors.monitorsFilePath | default `/etc/kuma-controller/monitors.yaml` }}"
           subPath: monitors.yaml
-        {{- end }}
-      {{- if .Values.kumaIngressWatcher.fileBasedMonitors.enabled }}
       volumes:
       - name: monitors-file
         configMap:
           name: {{ .Release.Name }}-monitors
-      {{- end }}
 {{- end }}

--- a/charts/kuma-ingress-watcher/templates/secret.yaml
+++ b/charts/kuma-ingress-watcher/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.kumaIngressWatcher.ingress.enabled .Values.kumaIngressWatcher.ingressRoute.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,3 +7,4 @@ metadata:
   annotations:
     kubernetes.io/service-account.name: {{ .Values.serviceAccount.name }}
 type: kubernetes.io/service-account-token
+{{- end }}

--- a/charts/kuma-ingress-watcher/templates/serviceaccount.yaml
+++ b/charts/kuma-ingress-watcher/templates/serviceaccount.yaml
@@ -1,5 +1,7 @@
+{{- if or .Values.kumaIngressWatcher.ingress.enabled .Values.kumaIngressWatcher.ingressRoute.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Values.namespace }}
+{{- end }}

--- a/charts/kuma-ingress-watcher/values.yaml
+++ b/charts/kuma-ingress-watcher/values.yaml
@@ -1,10 +1,23 @@
 kumaIngressWatcher:
   watchInterval: 10
   ingressRoute:
-    enabled: False
+    enabled: True
     traefikv3: False
   ingress:
-    enabled: True
+    enabled: False
+  fileBasedMonitors:
+    enabled: False
+    monitorsFilePath: "/etc/kuma-controller/monitors.yaml"
+    monitors:
+    #- name: "homie"
+    #  type: "http"
+    #  url: "https://homepage-192-168-1-28.traefik.me/"
+    #  interval: 60
+    #  - name: "another-monitor"
+    #    type: "http"
+    #    host: "example-host"
+    #    port: 8080
+    #    interval: 120
 
 namespace: monitoring
 
@@ -31,9 +44,6 @@ deployment:
 uptimeKuma:
   url: "http://uptime-kuma:3001"
   credentialsSecret: uptime-kuma-credentials
-
-configMap:
-  name: controller-scripts
 
 resources:
   requests:


### PR DESCRIPTION
Add logic to create a Kubernetes Job instead of a Deployment when file-based monitors are enabled and both ingress and ingressRoute are disabled. Job and deployement will mount the monitors file from a ConfigMap and set the necessary environment variables for the monitor configuration.